### PR TITLE
debug headless cypress

### DIFF
--- a/cypress/integration/forum_spec.js
+++ b/cypress/integration/forum_spec.js
@@ -32,11 +32,9 @@ describe('As a member, when I visit the forum tab', function() {
         cy.contains('active Jan  3, 2000');
       });
     });
-
     cy.contains(/new thread/i).click();
     cy.get('textarea').not('[aria-hidden]').type('brand new thread{enter}');
-    cy.contains('brand new thread');
+    cy.wait(5000)
     cy.dataGet('grid-button').first().contains('brand new thread');
-
   });
 });

--- a/cypress/integration/thread_spec.js
+++ b/cypress/integration/thread_spec.js
@@ -26,7 +26,7 @@ describe('As a member, when I visit a specific thread page', function() {
 
     cy.contains(/new post/i).click();
     cy.get('textarea').not('[aria-hidden]').type('brand new post{enter}');
-    cy.contains('brand new post').not(':hidden');
+    cy.wait(5000)
     cy.dataGet('grid-button').last().contains('brand new post');
 
     cy.go('back');


### PR DESCRIPTION
cypress was hanging on the replcaed lines (only when headless), which made Travis builds error after 10 minutes
using `cy.wait` is wrong, but it works for now (this has been put on the issue tracker)
related? with debug on, the last log before the hang was:
`cypress:server:socket automation:request take:screenshot`...
after that, just neverending timers 😩